### PR TITLE
change dependency prompt to promptly

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "repository": "https://github.com/manolodd/mosquitto-pbkdf2",
   "dependencies": {
     "pbkdf2": "3.0.14",
-    "prompt": "1.0.0"
+    "promptly": "3.0.3"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
the library "prompt" for the simple test script requires another lib with a security bug. The automatic snyk test tool flags this as low severity. As both libs (prompt and utile) are not updated for a long time i changed the np.js script to use another more activly maintained library without security warning.

<pre>
✗ Low severity vulnerability found in utile
  Description: Uninitialized Memory Exposure
  Info: https://snyk.io/vuln/npm:utile:20180614
  Introduced through: mosquitto-pbkdf2@0.2.1
  From: mosquitto-pbkdf2@0.2.1 > prompt@1.0.0 > utile@0.3.0
</pre>

After merging, please release a new version for all others to use. 

Thanks,
Stefan Seide